### PR TITLE
Drop py33 env

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 1.6
-envlist = py27,py33,py34,pep8
+envlist = py27,py34,pep8
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
We don't need to support this python version.
