### PR TITLE
Metadef plugin

### DIFF
--- a/searchlight/elasticsearch/plugins/base.py
+++ b/searchlight/elasticsearch/plugins/base.py
@@ -98,7 +98,8 @@ class IndexBase(object):
 
     def get_document_id_field(self):
         """Whatever document field should be treated as the id. This field
-        should also be mapped to _id in the elasticsearch mapping"""
+        should also be mapped to _id in the elasticsearch mapping
+        """
         return "id"
 
     @abc.abstractmethod

--- a/searchlight/elasticsearch/plugins/base.py
+++ b/searchlight/elasticsearch/plugins/base.py
@@ -29,6 +29,8 @@ class IndexBase(object):
         self.engine = searchlight.elasticsearch.get_api()
         self.index_name = self.get_index_name()
         self.document_type = self.get_document_type()
+        self.document_id_field = self.get_document_id_field()
+        self.name = "%s-%s" % (self.index_name, self.document_type)
 
     def setup(self):
         """Comprehensively install search engine index and put data into it."""
@@ -68,12 +70,12 @@ class IndexBase(object):
 
         self.save_documents(documents)
 
-    def save_documents(self, documents, id_field='id'):
+    def save_documents(self, documents):
         """Send list of serialized documents into search engine."""
         actions = []
         for document in documents:
             action = {
-                '_id': document.get(id_field),
+                '_id': document.get(self.document_id_field),
                 '_source': document,
             }
 
@@ -93,6 +95,11 @@ class IndexBase(object):
     @abc.abstractmethod
     def serialize(self, obj):
         """Serialize database object into valid search engine document."""
+
+    def get_document_id_field(self):
+        """Whatever document field should be treated as the id. This field
+        should also be mapped to _id in the elasticsearch mapping"""
+        return "id"
 
     @abc.abstractmethod
     def get_index_name(self):

--- a/searchlight/elasticsearch/plugins/glance/__init__.py
+++ b/searchlight/elasticsearch/plugins/glance/__init__.py
@@ -85,11 +85,12 @@ def serialize_glance_metadef_ns(metadef_namespace):
     def _serialize_object(obj):
         serialized_obj = {
             'name': obj['name'],
-            'description': obj['description'],
-            'properties': []
+            'description': obj['description']
         }
-        for name, property in six.iteritems(obj.get('properties', {})):
-            serialized_obj['properties'].append(_serialize_property(name, property))
+        serialized_obj['properties'] = [
+            _serialize_property(name, property)
+            for name, property in six.iteritems(obj.get('properties', {}))
+        ]
         return serialized_obj
 
     def _serialize_res_type(rt):
@@ -115,15 +116,19 @@ def serialize_glance_metadef_ns(metadef_namespace):
     document = dict((f, metadef_namespace.get(f, None))
                     for f in namespace_fields)
 
-    document['tags'] = [_serialize_tag(tag) for tag in metadef_namespace.get('tags', [])]
+    document['tags'] = [
+        _serialize_tag(tag) for tag in metadef_namespace.get('tags', [])
+    ]
     document['properties'] = [
         _serialize_property(name, property)
-        for name, property in six.iteritems(metadef_namespace.get('properties', {}))
+        for name, property in six.iteritems(
+            metadef_namespace.get('properties', {}))
     ]
     document['objects'] = [
         _serialize_object(obj) for obj in metadef_namespace.get('objects', [])
     ]
     document['resource_types'] = [
-        _serialize_res_type(rt) for rt in metadef_namespace.get('resource_type_associations', [])
+        _serialize_res_type(rt)
+        for rt in metadef_namespace.get('resource_type_associations', [])
     ]
     return document

--- a/searchlight/elasticsearch/plugins/glance/__init__.py
+++ b/searchlight/elasticsearch/plugins/glance/__init__.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import copy
 import glanceclient.exc
 from glanceclient.v1.images import Image as v1_image
 import logging
@@ -64,4 +65,63 @@ def serialize_glance_image(image):
     for kv in extra_properties:
         document[kv['name']] = kv['value']
 
+    return document
+
+
+def serialize_glance_metadef_ns(metadef_namespace):
+    def _serialize_tag(tag):
+        return {'name': tag['name']}
+
+    def _serialize_property(property):
+        serialized_prop = copy.deepcopy(property)
+        if 'default' in serialized_prop:
+            serialized_prop['default'] = str(serialized_prop['default'])
+        if 'enum' in serialized_prop:
+            serialized_prop['enum'] = map(str, serialized_prop['enum'])
+
+        return serialized_prop
+
+    def _serialize_object(obj):
+        serialized_obj = {
+            'name': obj['name'],
+            'description': obj['description'],
+            'properties': []
+        }
+        for property in obj['properties']:
+            serialized_obj['properties'].append(_serialize_property(property))
+        return serialized_obj
+
+    def _serialize_res_type(rt):
+        return {
+            'name': rt['name']
+        }
+
+    # TODO(sjmc7): test this better
+    incomplete = 'objects' not in metadef_namespace or \
+                 'properties' not in metadef_namespace or \
+                 'tags' not in metadef_namespace
+    if incomplete:
+        LOG.debug("Retrieving metadef namespace '%s'",
+                  metadef_namespace['namespace'])
+        g_client = openstack_clients.get_glanceclient()
+        metadef_namespace = g_client.metadefs_namespace.get(
+            metadef_namespace['namespace'])
+
+    # The CIS code specifically serialized some fields rather than indexing
+    # everything; do the same.
+    namespace_fields = ('namespace', 'display_name', 'description',
+                        'visibility', 'owner', 'protected')
+    document = dict((f, metadef_namespace.get(f, None))
+                    for f in namespace_fields)
+
+    document['tags'] = [_serialize_tag(tag) for tag in metadef_namespace['tags']]
+    document['properties'] = [
+        _serialize_property(property)
+        for property in metadef_namespace['properties']
+    ]
+    document['objects'] = [
+        _serialize_object(obj) for obj in metadef_namespace['objects']]
+    document['resource_types'] = [
+        _serialize_res_type(rt) for rt in metadef_namespace['resource_type_associations']
+    ]
     return document

--- a/searchlight/elasticsearch/plugins/glance/__init__.py
+++ b/searchlight/elasticsearch/plugins/glance/__init__.py
@@ -87,10 +87,10 @@ def serialize_glance_metadef_ns(metadef_namespace):
             'name': obj['name'],
             'description': obj['description']
         }
-        serialized_obj['properties'] = [
+        serialized_obj['properties'] = sorted([
             _serialize_property(name, property)
             for name, property in six.iteritems(obj.get('properties', {}))
-        ]
+        ])
         return serialized_obj
 
     def _serialize_res_type(rt):
@@ -116,19 +116,19 @@ def serialize_glance_metadef_ns(metadef_namespace):
     document = dict((f, metadef_namespace.get(f, None))
                     for f in namespace_fields)
 
-    document['tags'] = [
+    document['tags'] = sorted([
         _serialize_tag(tag) for tag in metadef_namespace.get('tags', [])
-    ]
-    document['properties'] = [
+    ])
+    document['properties'] = sorted([
         _serialize_property(name, property)
         for name, property in six.iteritems(
             metadef_namespace.get('properties', {}))
-    ]
-    document['objects'] = [
+    ])
+    document['objects'] = sorted([
         _serialize_object(obj) for obj in metadef_namespace.get('objects', [])
-    ]
-    document['resource_types'] = [
+    ])
+    document['resource_types'] = sorted([
         _serialize_res_type(rt)
         for rt in metadef_namespace.get('resource_type_associations', [])
-    ]
+    ])
     return document

--- a/searchlight/elasticsearch/plugins/glance/__init__.py
+++ b/searchlight/elasticsearch/plugins/glance/__init__.py
@@ -72,8 +72,9 @@ def serialize_glance_metadef_ns(metadef_namespace):
     def _serialize_tag(tag):
         return {'name': tag['name']}
 
-    def _serialize_property(property):
+    def _serialize_property(name, property):
         serialized_prop = copy.deepcopy(property)
+        serialized_prop['name'] = name
         if 'default' in serialized_prop:
             serialized_prop['default'] = str(serialized_prop['default'])
         if 'enum' in serialized_prop:
@@ -87,8 +88,8 @@ def serialize_glance_metadef_ns(metadef_namespace):
             'description': obj['description'],
             'properties': []
         }
-        for property in obj['properties']:
-            serialized_obj['properties'].append(_serialize_property(property))
+        for name, property in six.iteritems(obj.get('properties', {})):
+            serialized_obj['properties'].append(_serialize_property(name, property))
         return serialized_obj
 
     def _serialize_res_type(rt):
@@ -114,14 +115,15 @@ def serialize_glance_metadef_ns(metadef_namespace):
     document = dict((f, metadef_namespace.get(f, None))
                     for f in namespace_fields)
 
-    document['tags'] = [_serialize_tag(tag) for tag in metadef_namespace['tags']]
+    document['tags'] = [_serialize_tag(tag) for tag in metadef_namespace.get('tags', [])]
     document['properties'] = [
-        _serialize_property(property)
-        for property in metadef_namespace['properties']
+        _serialize_property(name, property)
+        for name, property in six.iteritems(metadef_namespace.get('properties', {}))
     ]
     document['objects'] = [
-        _serialize_object(obj) for obj in metadef_namespace['objects']]
+        _serialize_object(obj) for obj in metadef_namespace.get('objects', [])
+    ]
     document['resource_types'] = [
-        _serialize_res_type(rt) for rt in metadef_namespace['resource_type_associations']
+        _serialize_res_type(rt) for rt in metadef_namespace.get('resource_type_associations', [])
     ]
     return document

--- a/searchlight/elasticsearch/plugins/glance/metadefs.py
+++ b/searchlight/elasticsearch/plugins/glance/metadefs.py
@@ -16,7 +16,8 @@
 from searchlight.elasticsearch.plugins import base
 from searchlight.elasticsearch.plugins.glance \
     import metadefs_notification_handler
-# from searchlight.elasticsearch.plugins.glance import serialize_glance_metadef
+from searchlight.elasticsearch.plugins.glance \
+    import serialize_glance_metadef_ns
 
 
 class MetadefIndex(base.IndexBase):
@@ -34,7 +35,7 @@ class MetadefIndex(base.IndexBase):
             'dynamic': True,
             'type': 'nested',
             'properties': {
-                'property': {'type': 'string', 'index': 'not_analyzed'},
+                'name': {'type': 'string', 'index': 'not_analyzed'},
                 'type': {'type': 'string'},
                 'title': {'type': 'string'},
                 'description': {'type': 'string'},
@@ -54,8 +55,10 @@ class MetadefIndex(base.IndexBase):
                     'type': 'nested',
                     'properties': {
                         'name': {'type': 'string'},
-                        'prefix': {'type': 'string'},
-                        'properties_target': {'type': 'string'},
+                        # TODO(sjmc7): add these back in? They don't seem
+                        # to be accessible via the API
+                        #'prefix': {'type': 'string'},
+                        #'properties_target': {'type': 'string'},
                     },
                 },
                 'objects': {
@@ -115,6 +118,10 @@ class MetadefIndex(base.IndexBase):
         from searchlight.elasticsearch.plugins import openstack_clients
         gc = openstack_clients.get_glanceclient()
         return list(gc.metadefs_namespace.list())
+
+    def serialize(self, metadef_obj):
+        # TODO(sjmc7): don't do it like this
+        return serialize_glance_metadef_ns(metadef_obj)
 
     def get_notification_handler(self):
         return metadefs_notification_handler.MetadefHandler(

--- a/searchlight/elasticsearch/plugins/glance/metadefs.py
+++ b/searchlight/elasticsearch/plugins/glance/metadefs.py
@@ -60,8 +60,8 @@ class MetadefIndex(base.IndexBase):
                         'name': {'type': 'string'},
                         # TODO(sjmc7): add these back in? They don't seem
                         # to be accessible via the API
-                        #'prefix': {'type': 'string'},
-                        #'properties_target': {'type': 'string'},
+                        # 'prefix': {'type': 'string'},
+                        # 'properties_target': {'type': 'string'},
                     },
                 },
                 'objects': {

--- a/searchlight/elasticsearch/plugins/glance/metadefs.py
+++ b/searchlight/elasticsearch/plugins/glance/metadefs.py
@@ -30,6 +30,9 @@ class MetadefIndex(base.IndexBase):
     def get_document_type(self):
         return 'metadef'
 
+    def get_document_id_field(self):
+        return 'namespace'
+
     def get_mapping(self):
         property_mapping = {
             'dynamic': True,
@@ -120,7 +123,6 @@ class MetadefIndex(base.IndexBase):
         return list(gc.metadefs_namespace.list())
 
     def serialize(self, metadef_obj):
-        # TODO(sjmc7): don't do it like this
         return serialize_glance_metadef_ns(metadef_obj)
 
     def get_notification_handler(self):

--- a/searchlight/elasticsearch/plugins/openstack_clients.py
+++ b/searchlight/elasticsearch/plugins/openstack_clients.py
@@ -117,6 +117,7 @@ def get_glanceclient():
         service_type='image')
 
     return glanceclient.client.Client(
+        version=2,
         endpoint=endpoint,
         token=ks_client.auth_token,
         auth_url=ks_client.auth_url,

--- a/searchlight/tests/unit/test_glance_metadefs_plugin.py
+++ b/searchlight/tests/unit/test_glance_metadefs_plugin.py
@@ -13,9 +13,12 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+import copy
 import mock
 import unittest
 
+from searchlight.elasticsearch.plugins.glance import metadefs as md_plugin
+from searchlight.elasticsearch.plugins import openstack_clients
 import searchlight.tests.utils as test_utils
 
 
@@ -43,37 +46,44 @@ TAG2 = 'Tag2'
 TAG3 = 'Tag3'
 
 
-def _db_namespace_fixture(**kwargs):
+# TODO(sjmc7): Move this stuff to a fixtures module. These should match
+# responses from the glance v2 API
+def _namespace_fixture(**kwargs):
     obj = {
         'namespace': None,
         'display_name': None,
         'description': None,
-        'visibility': True,
-        'protected': False,
-        'owner': None
+        'visibility': 'public',
+        'protected': True,
+        'owner': None,
+        'schema': '/v2/schemas/metadefs/namespace',
+        'resource_type_associations': [],
+        'tags': [],
+        'objects': []
     }
     obj.update(kwargs)
-    return test_utils.DictObj(**obj)
+    return obj
 
 
-def _db_property_fixture(name, **kwargs):
-    obj = {
-        'name': name,
-        'json_schema': {"type": "string", "title": "title"},
-    }
-    obj.update(kwargs)
-    return test_utils.DictObj(**obj)
-
-
-def _db_object_fixture(name, **kwargs):
+def _property_fixture(name, **kwargs):
     obj = {
         'name': name,
         'description': None,
-        'json_schema': {},
-        'required': '[]',
+        'title': None,
+        'type': 'string'
     }
     obj.update(kwargs)
-    return test_utils.DictObj(**obj)
+    return obj
+
+
+def _object_fixture(name, **kwargs):
+    obj = {
+        'name': name,
+        'description': None,
+        'properties': []
+    }
+    obj.update(kwargs)
+    return obj
 
 
 def _db_resource_type_fixture(name, **kwargs):
@@ -82,10 +92,10 @@ def _db_resource_type_fixture(name, **kwargs):
         'protected': False,
     }
     obj.update(kwargs)
-    return test_utils.DictObj(**obj)
+    return obj
 
 
-def _db_namespace_resource_type_fixture(name, prefix, **kwargs):
+def _namespace_resource_type_fixture(name, prefix, **kwargs):
     obj = {
         'properties_target': None,
         'prefix': prefix,
@@ -95,158 +105,152 @@ def _db_namespace_resource_type_fixture(name, prefix, **kwargs):
     return obj
 
 
-def _db_tag_fixture(name, **kwargs):
+def _tag_fixture(name, **kwargs):
     obj = {
         'name': name,
     }
     obj.update(**kwargs)
-    return test_utils.DictObj(**obj)
+    return obj
 
 
 class TestMetadefLoaderPlugin(test_utils.BaseTestCase):
     def setUp(self):
         super(TestMetadefLoaderPlugin, self).setUp()
 
-        self._create_resource_types()
         self._create_namespaces()
         self._create_namespace_resource_types()
         self._create_properties()
         self._create_tags()
         self._create_objects()
 
-        # self.plugin = metadefs_plugin.MetadefIndex()
+        self.plugin = md_plugin.MetadefIndex()
+
+        mock_ks_client = mock.Mock()
+        mock_ks_client.service_catalog.url_for.return_value = \
+            'http://localhost/glance/v2'
+        patched_ks_client = mock.patch.object(
+            openstack_clients,
+            'get_keystoneclient',
+            return_value=mock_ks_client
+        )
+        patched_ks_client.start()
+        self.addCleanup(patched_ks_client.stop)
 
     def _create_namespaces(self):
         self.namespaces = [
-            _db_namespace_fixture(namespace=NAMESPACE1,
+            _namespace_fixture(namespace=NAMESPACE1,
                                   display_name='1',
                                   description='desc1',
                                   visibility='private',
                                   protected=True,
-                                  owner=TENANT1),
-            _db_namespace_fixture(namespace=NAMESPACE2,
+                                  owner=TENANT1,
+                                  resource_type_associations=[
+                                      {"name": RESOURCE_TYPE1}
+                                  ]),
+            _namespace_fixture(namespace=NAMESPACE2,
                                   display_name='2',
                                   description='desc2',
                                   visibility='public',
                                   protected=False,
-                                  owner=TENANT1),
+                                  owner=TENANT1,
+                                  resource_type_associations=[
+                                      {"name": RESOURCE_TYPE2},
+                                      {"name": RESOURCE_TYPE3}
+                                  ]),
         ]
 
     def _create_properties(self):
-        self.properties = [
-            _db_property_fixture(name=PROPERTY1),
-            _db_property_fixture(name=PROPERTY2),
-            _db_property_fixture(name=PROPERTY3)
+        properties = [
+            _property_fixture(name=PROPERTY1, title='title1'),
+            _property_fixture(name=PROPERTY2, title='title2'),
+            _property_fixture(name=PROPERTY3, title='title3')
         ]
 
-        self.namespaces[0].properties = [self.properties[0]]
-        self.namespaces[1].properties = self.properties[1:]
+        self.namespaces[0]['properties'] = properties[:1]
+        self.namespaces[1]['properties'] = properties[1:]
 
     def _create_objects(self):
-        self.objects = [
-            _db_object_fixture(name=OBJECT1,
+        objects = [
+            _object_fixture(name=OBJECT1,
                                description='desc1',
-                               json_schema={'property1': {
-                                   'type': 'string',
-                                   'default': 'value1',
-                                   'enum': ['value1', 'value2']
-                               }}),
-            _db_object_fixture(name=OBJECT2,
-                               description='desc2'),
-            _db_object_fixture(name=OBJECT3,
-                               description='desc3'),
+                               properties=[_property_fixture(
+                                   name='property1',
+                                   type='string',
+                                   enum=['value1', 'value2'],
+                                   default='value1',
+                                   title='something title')]
+                           ),
+            _object_fixture(name=OBJECT2,
+                            description='desc2'),
+            _object_fixture(name=OBJECT3,
+                            description='desc3'),
         ]
 
-        self.namespaces[0].objects = [self.objects[0]]
-        self.namespaces[1].objects = self.objects[1:]
+        self.namespaces[0]['objects'] = objects[:1]
+        self.namespaces[1]['objects'] = objects[1:]
 
-    def _create_resource_types(self):
+    def ___create_resource_types(self):
         self.resource_types = [
-            _db_resource_type_fixture(name=RESOURCE_TYPE1,
+            _resource_type_fixture(name=RESOURCE_TYPE1,
                                       protected=False),
-            _db_resource_type_fixture(name=RESOURCE_TYPE2,
+            _resource_type_fixture(name=RESOURCE_TYPE2,
                                       protected=False),
-            _db_resource_type_fixture(name=RESOURCE_TYPE3,
+            _resource_type_fixture(name=RESOURCE_TYPE3,
                                       protected=True),
         ]
 
     def _create_namespace_resource_types(self):
-        self.namespace_resource_types = [
-            _db_namespace_resource_type_fixture(
+        namespace_resource_types = [
+            _namespace_resource_type_fixture(
                 prefix='p1',
-                name=self.resource_types[0].name),
-            _db_namespace_resource_type_fixture(
+                name=RESOURCE_TYPE1),
+            _namespace_resource_type_fixture(
                 prefix='p2',
-                name=self.resource_types[1].name),
-            _db_namespace_resource_type_fixture(
+                name=RESOURCE_TYPE2),
+            _namespace_resource_type_fixture(
                 prefix='p2',
-                name=self.resource_types[2].name),
+                name=RESOURCE_TYPE3),
         ]
-        self.namespaces[0].resource_types = self.namespace_resource_types[:1]
-        self.namespaces[1].resource_types = self.namespace_resource_types[1:]
+        self.namespaces[0]['resource_type_associations'] = \
+            namespace_resource_types[:1]
+        self.namespaces[1]['resource_type_associations'] = \
+            namespace_resource_types[1:]
 
     def _create_tags(self):
-        self.tags = [
-            _db_resource_type_fixture(name=TAG1),
-            _db_resource_type_fixture(name=TAG2),
-            _db_resource_type_fixture(name=TAG3),
+        tags = [
+            _tag_fixture(name=TAG1),
+            _tag_fixture(name=TAG2),
+            _tag_fixture(name=TAG3),
         ]
-        self.namespaces[0].tags = self.tags[:1]
-        self.namespaces[1].tags = self.tags[1:]
+        self.namespaces[0]['tags'] = tags[:1]
+        self.namespaces[1]['tags'] = tags[1:]
 
-    @unittest.skip("Skipping metadefs")
+    def _get_namespace(self, namespace):
+        """The 'get' namespace API call returns everything (objects, properties,
+        resource type allocations) whereas 'list' does not"""
+        if isinstance(namespace, int):
+            return self.namespaces[namespace]
+        else:
+            return filter(lambda n: n['namespace'] == namespace,
+                          self.namespaces)[0]
+
+    def _list_namespaces(self):
+        """Return a stripped down copy of namespaces, minus tags, properties,
+        objects, similar to glanceclient"""
+        for namespace in self.namespaces:
+            ns_copy = copy.deepcopy(namespace)
+            del ns_copy['tags']
+            del ns_copy['properties']
+            del ns_copy['objects']
+            yield ns_copy
+
     def test_index_name(self):
         self.assertEqual('glance', self.plugin.get_index_name())
 
-    @unittest.skip("Skipping metadefs")
     def test_document_type(self):
         self.assertEqual('metadef', self.plugin.get_document_type())
 
-    @unittest.skip("Skipping metadefs")
-    def test_namespace_serialize(self):
-        metadef_namespace = self.namespaces[0]
-        expected = {
-            'namespace': 'namespace1',
-            'display_name': '1',
-            'description': 'desc1',
-            'visibility': 'private',
-            'protected': True,
-            'owner': '6838eb7b-6ded-434a-882c-b344c77fe8df'
-        }
-        serialized = self.plugin.serialize_namespace(metadef_namespace)
-        self.assertEqual(expected, serialized)
-
-    @unittest.skip("Skipping metadefs")
-    def test_object_serialize(self):
-        metadef_object = self.objects[0]
-        expected = {
-            'name': 'Object1',
-            'description': 'desc1',
-            'properties': [{
-                'default': 'value1',
-                'enum': ['value1', 'value2'],
-                'property': 'property1',
-                'type': 'string'
-            }]
-        }
-        serialized = self.plugin.serialize_object(metadef_object)
-        self.assertEqual(expected, serialized)
-
-    @unittest.skip("Skipping metadefs")
-    def test_property_serialize(self):
-        metadef_property = self.properties[0]
-        expected = {
-            'property': 'Property1',
-            'type': 'string',
-            'title': 'title',
-        }
-        serialized = self.plugin.serialize_property(
-            metadef_property.name, metadef_property.json_schema)
-        self.assertEqual(expected, serialized)
-
-    @unittest.skip("Skipping metadefs")
     def test_complex_serialize(self):
-        metadef_namespace = self.namespaces[0]
         expected = {
             'namespace': 'namespace1',
             'display_name': '1',
@@ -259,27 +263,35 @@ class TestMetadefLoaderPlugin(test_utils.BaseTestCase):
                 'name': 'Object1',
                 'properties': [{
                     'default': 'value1',
+                    'description': None,
                     'enum': ['value1', 'value2'],
-                    'property': 'property1',
-                    'type': 'string'
+                    'name': 'property1',
+                    'type': 'string',
+                    'title': 'something title'
                 }]
             }],
             'resource_types': [{
-                'prefix': 'p1',
+                # TODO(sjmc7): Removing these because i'm not sure we
+                # have access to them
+                #'prefix': 'p1',
                 'name': 'ResourceType1',
-                'properties_target': None
+                #'properties_target': None
             }],
             'properties': [{
-                'property': 'Property1',
-                'title': 'title',
-                'type': 'string'
+                'name': 'Property1',
+                'title': 'title1',
+                'type': 'string',
+                'description': None
             }],
             'tags': [{'name': 'Tag1'}],
         }
-        serialized = self.plugin.serialize(metadef_namespace)
+
+        ns = list(self._list_namespaces())[0]
+        with mock.patch('glanceclient.v2.metadefs.NamespaceController.get',
+                               return_value=self._get_namespace(ns['namespace'])):
+            serialized = self.plugin.serialize(ns)
         self.assertEqual(expected, serialized)
 
-    @unittest.skip("Skipping metadefs")
     def test_setup_data(self):
         with mock.patch.object(self.plugin, 'get_objects',
                                return_value=self.namespaces) as mock_get:
@@ -297,9 +309,11 @@ class TestMetadefLoaderPlugin(test_utils.BaseTestCase):
                                 'description': 'desc1',
                                 'properties': [{
                                     'default': 'value1',
-                                    'property': 'property1',
+                                    'name': 'property1',
                                     'enum': ['value1', 'value2'],
-                                    'type': 'string'
+                                    'type': 'string',
+                                    'title': 'something title',
+                                    'description': None
                                 }],
                             }
                         ],
@@ -308,14 +322,13 @@ class TestMetadefLoaderPlugin(test_utils.BaseTestCase):
                         'protected': True,
                         'owner': '6838eb7b-6ded-434a-882c-b344c77fe8df',
                         'properties': [{
-                            'property': 'Property1',
+                            'name': 'Property1',
                             'type': 'string',
-                            'title': 'title'
+                            'title': 'title1',
+                            'description': None
                         }],
                         'resource_types': [{
-                            'prefix': 'p1',
                             'name': 'ResourceType1',
-                            'properties_target': None
                         }],
                         'tags': [{'name': 'Tag1'}],
                     },
@@ -340,26 +353,24 @@ class TestMetadefLoaderPlugin(test_utils.BaseTestCase):
                         'owner': '6838eb7b-6ded-434a-882c-b344c77fe8df',
                         'properties': [
                             {
-                                'property': 'Property2',
+                                'name': 'Property2',
                                 'type': 'string',
-                                'title': 'title'
+                                'title': 'title2',
+                                'description': None
                             },
                             {
-                                'property': 'Property3',
+                                'name': 'Property3',
                                 'type': 'string',
-                                'title': 'title'
+                                'title': 'title3',
+                                'description': None
                             }
                         ],
                         'resource_types': [
                             {
-                                'name': 'ResourceType2',
-                                'prefix': 'p2',
-                                'properties_target': None,
+                                'name': 'ResourceType2'
                             },
                             {
-                                'name': 'ResourceType3',
-                                'prefix': 'p2',
-                                'properties_target': None,
+                                'name': 'ResourceType3'
                             }
                         ],
                         'tags': [

--- a/searchlight/tests/unit/test_glance_metadefs_plugin.py
+++ b/searchlight/tests/unit/test_glance_metadefs_plugin.py
@@ -15,7 +15,6 @@
 
 import copy
 import mock
-import unittest
 
 from searchlight.elasticsearch.plugins.glance import metadefs as md_plugin
 from searchlight.elasticsearch.plugins import openstack_clients
@@ -139,24 +138,24 @@ class TestMetadefLoaderPlugin(test_utils.BaseTestCase):
     def _create_namespaces(self):
         self.namespaces = [
             _namespace_fixture(namespace=NAMESPACE1,
-                                  display_name='1',
-                                  description='desc1',
-                                  visibility='private',
-                                  protected=True,
-                                  owner=TENANT1,
-                                  resource_type_associations=[
-                                      {"name": RESOURCE_TYPE1}
-                                  ]),
+                               display_name='1',
+                               description='desc1',
+                               visibility='private',
+                               protected=True,
+                               owner=TENANT1,
+                               resource_type_associations=[
+                                   {"name": RESOURCE_TYPE1}
+                               ]),
             _namespace_fixture(namespace=NAMESPACE2,
-                                  display_name='2',
-                                  description='desc2',
-                                  visibility='public',
-                                  protected=False,
-                                  owner=TENANT1,
-                                  resource_type_associations=[
-                                      {"name": RESOURCE_TYPE2},
-                                      {"name": RESOURCE_TYPE3}
-                                  ]),
+                               display_name='2',
+                               description='desc2',
+                               visibility='public',
+                               protected=False,
+                               owner=TENANT1,
+                               resource_type_associations=[
+                                   {"name": RESOURCE_TYPE2},
+                                   {"name": RESOURCE_TYPE3}
+                               ]),
         ]
 
     def _create_properties(self):
@@ -194,16 +193,6 @@ class TestMetadefLoaderPlugin(test_utils.BaseTestCase):
         self.namespaces[0]['objects'] = objects[:1]
         self.namespaces[1]['objects'] = objects[1:]
 
-    def ___create_resource_types(self):
-        self.resource_types = [
-            _resource_type_fixture(name=RESOURCE_TYPE1,
-                                      protected=False),
-            _resource_type_fixture(name=RESOURCE_TYPE2,
-                                      protected=False),
-            _resource_type_fixture(name=RESOURCE_TYPE3,
-                                      protected=True),
-        ]
-
     def _create_namespace_resource_types(self):
         namespace_resource_types = [
             _namespace_resource_type_fixture(
@@ -232,7 +221,8 @@ class TestMetadefLoaderPlugin(test_utils.BaseTestCase):
 
     def _get_namespace(self, namespace):
         """The 'get' namespace API call returns everything (objects, properties,
-        resource type allocations) whereas 'list' does not"""
+        resource type allocations) whereas 'list' does not.
+        """
         if isinstance(namespace, int):
             return self.namespaces[namespace]
         else:
@@ -241,7 +231,8 @@ class TestMetadefLoaderPlugin(test_utils.BaseTestCase):
 
     def _list_namespaces(self):
         """Return a stripped down copy of namespaces, minus tags, properties,
-        objects, similar to glanceclient"""
+        objects, similar to glanceclient.
+        """
         for namespace in self.namespaces:
             ns_copy = copy.deepcopy(namespace)
             del ns_copy['tags']
@@ -278,9 +269,9 @@ class TestMetadefLoaderPlugin(test_utils.BaseTestCase):
             'resource_types': [{
                 # TODO(sjmc7): Removing these because i'm not sure we
                 # have access to them
-                #'prefix': 'p1',
+                # 'prefix': 'p1',
                 'name': 'ResourceType1',
-                #'properties_target': None
+                # 'properties_target': None
             }],
             'properties': [{
                 'name': 'Property1',
@@ -293,7 +284,7 @@ class TestMetadefLoaderPlugin(test_utils.BaseTestCase):
 
         ns = list(self._list_namespaces())[0]
         with mock.patch('glanceclient.v2.metadefs.NamespaceController.get',
-                               return_value=self._get_namespace(ns['namespace'])):
+                        return_value=self._get_namespace(ns['namespace'])):
             serialized = self.plugin.serialize(ns)
         self.assertEqual(expected, serialized)
 
@@ -324,9 +315,9 @@ class TestMetadefLoaderPlugin(test_utils.BaseTestCase):
             'resource_types': [{
                 # TODO(sjmc7): Removing these because i'm not sure we
                 # have access to them
-                #'prefix': 'p1',
+                # 'prefix': 'p1',
                 'name': 'ResourceType1',
-                #'properties_target': None
+                # 'properties_target': None
             }],
             'properties': [{
                 'name': 'Property1',
@@ -337,7 +328,7 @@ class TestMetadefLoaderPlugin(test_utils.BaseTestCase):
             'tags': [],
         }
         with mock.patch('glanceclient.v2.metadefs.NamespaceController.get',
-                               return_value=return_value):
+                        return_value=return_value):
             serialized = self.plugin.serialize(ns)
         self.assertEqual(expected, serialized)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ oslo.config.opts =
     searchlight.api = searchlight.opts:list_api_opts
 searchlight.index_backend =
     image = searchlight.elasticsearch.plugins.glance.images:ImageIndex
-    metadef = searchlight.elasticsearch.plugins.metadefs:MetadefIndex
+    metadef = searchlight.elasticsearch.plugins.glance.metadefs:MetadefIndex
 
 oslo.config.opts =
     searchlight = searchlight.opts:list_opts

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ oslo.config.opts =
     searchlight.api = searchlight.opts:list_api_opts
 searchlight.index_backend =
     image = searchlight.elasticsearch.plugins.glance.images:ImageIndex
-#    metadef = searchlight.elasticsearch.plugins.metadefs:MetadefIndex
+    metadef = searchlight.elasticsearch.plugins.metadefs:MetadefIndex
 
 oslo.config.opts =
     searchlight = searchlight.opts:list_opts


### PR DESCRIPTION
Adds back in the metadef plugin. Tested initial indexing and notifications for namespace updates; the other update code remains unchanged but may need looking at in future. Update operations essentially do a re-index and I'm not sure if maintaining the complexity here is worth it.
